### PR TITLE
Always use node-fetch and stop polyfilling

### DIFF
--- a/packages/isomorphic-unfetch/index.js
+++ b/packages/isomorphic-unfetch/index.js
@@ -1,10 +1,8 @@
 function r(m) {
 	return (m && m.default) || m;
 }
-module.exports = global.fetch =
-	global.fetch ||
-	(typeof process == "undefined"
-		? r(require("unfetch"))
+module.exports = (typeof process == "undefined"
+		? global.fetch || r(require("unfetch"))
 		: function (url, opts) {
 				if (typeof url === "string" || url instanceof URL) {
 					url = String(url).replace(/^\/\//g, "https://");

--- a/packages/isomorphic-unfetch/index.mjs
+++ b/packages/isomorphic-unfetch/index.mjs
@@ -1,10 +1,8 @@
 function r(m) {
 	return (m && m.default) || m;
 }
-export default global.fetch =
-	global.fetch ||
-	(typeof process == "undefined"
-		? function (url, opts) {
+export default fetch = (typeof process == "undefined"
+		? global.fetch || function (url, opts) {
 				return import("unfetch").then((m) => r(m)(url, opts));
 		  }
 		: function (url, opts) {

--- a/test/isomorphic.test.js
+++ b/test/isomorphic.test.js
@@ -87,7 +87,7 @@ describe("isomorphic-unfetch", () => {
 	});
 
 	describe('"main" entry in NodeJS', () => {
-		it("should resolve to fetch when window.fetch exists", async () => {
+		it("should resolve to node-fetch (changed from upstream for Plasmic) when window.fetch exists", async () => {
 			let sandbox = {
 				process: {},
 				global: { fetch },
@@ -117,7 +117,7 @@ describe("isomorphic-unfetch", () => {
 
 			const ns = mod.namespace;
 
-			expect(await ns.default("/")).toBe("this is fetch");
+			expect(await ns.default("/")).toBe("this is node-fetch");
 		});
 
 		it("should resolve to node-fetch when window.fetch does not exist", async () => {

--- a/test/isomorphic.test.js
+++ b/test/isomorphic.test.js
@@ -1,20 +1,29 @@
 import fs from "fs";
 import vm from "vm";
 
+const fetch = () => "this is fetch";
+const unfetch = () => "this is unfetch";
+const nodeFetch = {
+	default: () => "this is node-fetch",
+};
+
+const modules = {
+	unfetch,
+	"node-fetch": nodeFetch
+};
+function customRequire(module) {
+	return modules[module];
+}
+
 describe("isomorphic-unfetch", () => {
 	describe('"browser" entry', () => {
 		it("should resolve to fetch when window.fetch exists", () => {
-			function fetch() {
-				return this;
-			}
-			function unfetch() {}
-
 			let sandbox = {
 				process: undefined,
 				window: { fetch },
 				fetch,
 				exports: {},
-				require: () => unfetch,
+				require: customRequire,
 			};
 			sandbox.global = sandbox.self = sandbox.window;
 			sandbox.module = { exports: sandbox.exports };
@@ -27,13 +36,11 @@ describe("isomorphic-unfetch", () => {
 		});
 
 		it("should resolve to unfetch when window.fetch does not exist", () => {
-			function unfetch() {}
-
 			let sandbox = {
 				process: undefined,
 				window: {},
 				exports: {},
-				require: () => unfetch,
+				require: customRequire,
 			};
 			sandbox.global = sandbox.self = sandbox.window;
 			sandbox.module = { exports: sandbox.exports };
@@ -48,17 +55,12 @@ describe("isomorphic-unfetch", () => {
 
 	describe('"main" entry', () => {
 		it("should resolve to fetch when window.fetch exists", () => {
-			function fetch() {
-				return this;
-			}
-			function unfetch() {}
-
 			let sandbox = {
 				process: undefined,
 				window: { fetch },
 				fetch,
 				exports: {},
-				require: () => unfetch,
+				require: customRequire,
 			};
 			sandbox.global = sandbox.self = sandbox.window;
 			sandbox.module = { exports: sandbox.exports };
@@ -69,13 +71,11 @@ describe("isomorphic-unfetch", () => {
 		});
 
 		it("should resolve to unfetch when window.fetch does not exist", () => {
-			function unfetch() {}
-
 			let sandbox = {
 				process: undefined,
 				window: {},
 				exports: {},
-				require: () => unfetch,
+				require: customRequire,
 			};
 			sandbox.global = sandbox.self = sandbox.window;
 			sandbox.module = { exports: sandbox.exports };
@@ -87,42 +87,12 @@ describe("isomorphic-unfetch", () => {
 	});
 
 	describe('"main" entry in NodeJS', () => {
-		it("should resolve to fetch when window.fetch exists", () => {
-			function fetch() {
-				return this;
-			}
-			function unfetch() {}
-
+		it("should resolve to fetch when window.fetch exists", async () => {
 			let sandbox = {
 				process: {},
 				global: { fetch },
 				exports: {},
-				require: () => unfetch,
-			};
-			sandbox.module = { exports: sandbox.exports };
-			let filename = require.resolve("../packages/isomorphic-unfetch");
-			vm.runInNewContext(fs.readFileSync(filename, "utf8"), sandbox, filename);
-
-			expect(sandbox.module.exports).toBe(fetch);
-		});
-
-		it("should resolve to unfetch when window.fetch does not exist", async () => {
-			let modules = {
-				unfetch() {},
-				"node-fetch": {
-					default: function nodeFetch(url) {
-						return "hello from node-fetch";
-					},
-				},
-			};
-
-			let sandbox = {
-				process: {},
-				global: {
-					fetch: null,
-				},
-				exports: {},
-				require: (module) => modules[module],
+				require: customRequire,
 			};
 			sandbox.global.process = sandbox.process;
 			sandbox.module = { exports: sandbox.exports };
@@ -147,9 +117,42 @@ describe("isomorphic-unfetch", () => {
 
 			const ns = mod.namespace;
 
-			expect(await ns.default("/")).toBe(
-				await modules["node-fetch"].default("/")
-			);
+			expect(await ns.default("/")).toBe("this is fetch");
+		});
+
+		it("should resolve to node-fetch when window.fetch does not exist", async () => {
+			let sandbox = {
+				process: {},
+				global: {
+					fetch: null,
+				},
+				exports: {},
+				require: customRequire,
+			};
+			sandbox.global.process = sandbox.process;
+			sandbox.module = { exports: sandbox.exports };
+			let filename = require
+				.resolve("../packages/isomorphic-unfetch")
+				.replace(/\.js$/, ".mjs");
+			const context = vm.createContext(sandbox);
+			const mod = new vm.SourceTextModule(fs.readFileSync(filename, "utf8"), {
+				context,
+				async importModuleDynamically(specifier, script, assertions) {
+					const exp = modules[specifier];
+					const module = new vm.SyntheticModule(Object.keys(exp), () => {
+						for (let key in exp) module.setExport(key, exp[key]);
+					});
+					await module.link(() => {});
+					await module.evaluate();
+					return module;
+				},
+			});
+			await mod.link(() => {});
+			await mod.evaluate();
+
+			const ns = mod.namespace;
+
+			expect(await ns.default("/")).toBe("this is node-fetch");
 		});
 	});
 });


### PR DESCRIPTION
Due to a bug in undici (https://github.com/nodejs/undici/issues/1776)
that is affecting many versions of Node and Next.js,
we want a workaround to ensure our users don't see this.

Therefore, we're forking isomorphic-unfetch to always use node-fetch
on Node to avoid falling back to global.fetch (undici).

Also, isomorphic-unfetch was polyfilling, which we want to avoid.